### PR TITLE
Check if the instance is running for the CI before logging caches.

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1688,7 +1688,7 @@ class BaseModel(metaclass=MetaModel):
         This clears the caches associated to methods decorated with
         ``tools.ormcache`` or ``tools.ormcache_multi``.
         """
-        if logstack:
+        if logstack and not config.get("CI"):
             from io import StringIO
             import traceback
             fobj = StringIO()


### PR DESCRIPTION
This aims to avoid Travis failing because of `The job exceeded the maximum log length, and has been terminated.`